### PR TITLE
Update jade.js

### DIFF
--- a/tasks/jade.js
+++ b/tasks/jade.js
@@ -89,7 +89,14 @@ module.exports = function(grunt) {
         }
 
         if (options.client && options.namespace !== false) {
-          templates.push(nsInfo.namespace + '[' + JSON.stringify(filename) + '] = ' + compiled + ';');
+          var ns;
+          if (options.dir) {
+             var relPath = filename.replace(new RegExp('^'+options.dir), '');
+             ns = '["' + relPath.replace(/\//gi, '"]["') + '"]';
+          } else
+             ns = '[' + JSON.stringify(filename) + ']';
+
+          templates.push(nsInfo.namespace + ns + ' = ' + compiled + ';');
         } else {
           templates.push(compiled);
         }


### PR DESCRIPTION
There is a small inconvenience to work with generated namespaces on client side. It would be nice to add a new "dir" option as relative path to the "root folder containing templates".

If you have a deep folder tree (complex project) then filename is too long in the target client's js amd file.

I.e., using this fix you can use your template on client side as product.card