### PR TITLE
make filepath available in processContent

### DIFF
--- a/tasks/jade.js
+++ b/tasks/jade.js
@@ -51,7 +51,7 @@ module.exports = function(grunt) {
         }
       })
       .forEach(function(filepath) {
-        var src = processContent(grunt.file.read(filepath));
+        var src = processContent(grunt.file.read(filepath), filepath);
         var compiled, filename;
         filename = processName(filepath);
 


### PR DESCRIPTION
I have a case where I need more information about what I'm compiling in ``processContent`` such as the filename.

```js
processContent: function(content, filename) {
  var prefix = "// source file: " + filename + "\n\n"
  return prefix + content;
}
```