### PR TITLE
Add config option so Jade AMD can specify dependencies

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -65,6 +65,27 @@ module.exports = function(grunt) {
         }
       },
 
+      compile_amd_with_dependencies: {
+        files: {
+          'tmp/amd/jadeDeps.js': ['test/fixtures/jade.jade'],
+          'tmp/amd/jade2Deps.js': ['test/fixtures/jade2.jade'],
+        },
+        options: {
+          client: true,
+          amd: true,
+          amdDeps: [
+            'moment',
+            'another'
+          ],
+          namespace: false,
+          compileDebug: false,
+          data: {
+            test: true,
+            year: '<%= grunt.template.today("yyyy") %>'
+          }
+        }
+      },
+
       compile_jst: {
         files: {
           'tmp/jst/jade.js': ['test/fixtures/jade.jade'],

--- a/tasks/jade.js
+++ b/tasks/jade.js
@@ -114,7 +114,28 @@ module.exports = function(grunt) {
 
         if (options.amd) {
           // wrap the file in an AMD define function
-          output.unshift('define([\'jade\'], function(jade) { if(jade && jade[\'runtime\'] !== undefined) { jade = jade.runtime; }');
+          var amdBuffer = [];
+          if (options.amdDeps) {
+            amdBuffer.push('define([\'jade\'');
+
+            options.amdDeps.forEach(function(dep) {
+              amdBuffer.push(', \'' + dep + '\'');
+            });
+
+            amdBuffer.push('], function(jade');
+
+            options.amdDeps.forEach(function(dep) {
+              console.log("param: " + dep);
+              amdBuffer.push(', ' + dep);
+            });
+
+            amdBuffer.push(')');
+          } else {
+            amdBuffer.push('define([\'jade\'], function(jade)');
+          }
+          amdBuffer.push(' { if(jade && jade[\'runtime\'] !== undefined) { jade = jade.runtime; }');
+          output.unshift(amdBuffer.join(''));
+
           if (options.namespace !== false) {
             // namespace has not been explicitly set to false;
             // the AMD wrapper will return the object containing the template

--- a/test/expected/amd/jade2Deps.js
+++ b/test/expected/amd/jade2Deps.js
@@ -1,0 +1,16 @@
+define(['jade', 'moment', 'another'], function(jade, moment, another) { if(jade && jade['runtime'] !== undefined) { jade = jade.runtime; }
+
+return function template(locals) {
+var buf = [];
+var jade_mixins = {};
+var jade_interp;
+;var locals_for_with = (locals || {});(function (test) {
+buf.push("<div id=\"test\" class=\"test\"><span id=\"data\">data</span>");
+if ( test)
+{
+buf.push("<div>testing 2</div>");
+}
+buf.push("</div>");}.call(this,"test" in locals_for_with?locals_for_with.test:typeof test!=="undefined"?test:undefined));;return buf.join("");
+}
+
+});

--- a/test/expected/amd/jadeDeps.js
+++ b/test/expected/amd/jadeDeps.js
@@ -1,0 +1,16 @@
+define(['jade', 'moment', 'another'], function(jade, moment, another) { if(jade && jade['runtime'] !== undefined) { jade = jade.runtime; }
+
+return function template(locals) {
+var buf = [];
+var jade_mixins = {};
+var jade_interp;
+;var locals_for_with = (locals || {});(function (test) {
+buf.push("<div id=\"test\" class=\"test\"><span id=\"data\">data</span>");
+if ( test)
+{
+buf.push("<div>testing</div>");
+}
+buf.push("</div>");}.call(this,"test" in locals_for_with?locals_for_with.test:typeof test!=="undefined"?test:undefined));;return buf.join("");
+}
+
+});

--- a/test/jade_amd_test.js
+++ b/test/jade_amd_test.js
@@ -8,7 +8,7 @@ exports.jade = {
   compile: function(test) {
     'use strict';
 
-    test.expect(4);
+    test.expect(6);
 
     var actual = read('tmp/amd/jade.js');
     var expected = read('test/expected/amd/jade.js');
@@ -25,6 +25,14 @@ exports.jade = {
     actual = read('tmp/amd/jadeTemplate.js');
     expected = read('test/expected/amd/jadeTemplate.js');
     test.equal(expected, actual, 'should compile jade templates to js with grunt template support');
+
+    actual = read('tmp/amd/jadeDeps.js');
+    expected = read('test/expected/amd/jadeDeps.js');
+    test.equal(expected, actual, 'should compile jade templates to js with AMD dependencies');
+
+    actual = read('tmp/amd/jade2Deps.js');
+    expected = read('test/expected/amd/jade2Deps.js');
+    test.equal(expected, actual, 'should compile jade templates to js with AMD dependencies');
 
     test.done();
   }


### PR DESCRIPTION
So I was having some trouble with the way `grunt-contrib-jade` wrapped up the jade templates as an AMD module. The plugin currently wraps using
```js
define(['jade'], function(jade) { if(jade && jade['runtime'] !== undefined) { jade = jade.runtime; }
```
but it would be nice to be able to specify any requirements of the templates like 
```js
define(['jade', 'moment', 'another'], function(jade, moment, another) { if(jade && jade['runtime'] !== undefined) { jade = jade.runtime; }
```
That way I can references things like moment inside my jade templates without using the global namespace -- something that [moment has deprecated](https://github.com/jnordberg/wintersmith/issues/184) and will be removing in future releases. 

My suggested change is that the plugin adds another config option called `amdDeps` (totally open to a name change suggestion but I can't think of anything better without creating a breaking change to the config)
```js
compile: {
  options: {
    amd: true,
    amdDeps: [
      'moment',
      'another'
    ],
  }
}
```
I added two tests to show that my changes work -- one might have done but I kinda wanted to prove the point. 

I haven't updated the documentation in this PR but if it seems like a change that makes sense to add into the plugin then I'm more than happy to add documentation changes in too.