### PR TITLE
Update jade to 1.11.0 and add a test for code-blocks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+v0.15.0:
+  date: 2015-07-08
+  changes:
+    - Update to jade 1.11.0.
+    - Add test for Codeblocks
 v0.14.1:
   date: 2014-02-02
   changes:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,7 +36,8 @@ module.exports = function(grunt) {
           'tmp/jade2.html': ['test/fixtures/jade2.jade'],
           'tmp/jadeInclude.html': ['test/fixtures/jadeInclude.jade'],
           'tmp/jadeTemplate.html': ['test/fixtures/jadeTemplate.jade'],
-          'tmp/jadeUsingmixin.html': ['test/fixtures/jadeUsingmixin.jade']
+          'tmp/jadeUsingmixin.html': ['test/fixtures/jadeUsingmixin.jade'],
+          'tmp/jadeCodeBlock.html': ['test/fixtures/jadeCodeBlock.jade']
         },
         options: {
           data: {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# grunt-contrib-jade v0.14.0 [![Build Status: Linux](https://travis-ci.org/gruntjs/grunt-contrib-jade.svg?branch=master)](https://travis-ci.org/gruntjs/grunt-contrib-jade) [![Build Status: Windows](https://ci.appveyor.com/api/projects/status/p24tu0v9akk906yq/branch/master?svg=true)](https://ci.appveyor.com/project/gruntjs/grunt-contrib-jade/branch/master)
+# grunt-contrib-jade v0.15.0 [![Build Status: Linux](https://travis-ci.org/gruntjs/grunt-contrib-jade.svg?branch=master)](https://travis-ci.org/gruntjs/grunt-contrib-jade) [![Build Status: Windows](https://ci.appveyor.com/api/projects/status/p24tu0v9akk906yq/branch/master?svg=true)](https://ci.appveyor.com/project/gruntjs/grunt-contrib-jade/branch/master)
 
 > Compile Jade templates.
 
@@ -240,6 +240,7 @@ jade: {
 
 ## Release History
 
+ * 2015-07-08   v0.15.0   Update to jade 1.11.0.
  * 2014-12-23   v0.14.0   Update to jade 1.8.2.
  * 2014-09-30   v0.13.0   Update to jade 1.7.0.
  * 2014-05-29   v0.12.0   Update to jade 1.3. Make jade task to fail on an error.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "chalk": "^1.0.0",
-    "jade": "^1.9.1"
+    "jade": "^1.11.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/test/expected/jadeCodeBlock.html
+++ b/test/expected/jadeCodeBlock.html
@@ -1,0 +1,1 @@
+<li>Uno</li><li>Dos</li><li>Tres</li><li>Cuatro</li><li>Cinco</li><li>Seis</li>

--- a/test/fixtures/jadeCodeBlock.jade
+++ b/test/fixtures/jadeCodeBlock.jade
@@ -1,0 +1,6 @@
+-
+  list = ["Uno", "Dos", "Tres",
+            "Cuatro", "Cinco", "Seis"]
+  
+each item in list
+  li= item

--- a/test/jade_test.js
+++ b/test/jade_test.js
@@ -9,7 +9,7 @@ var read = function(src) {
 exports.jade = {
   compile: function(test) {
 
-    test.expect(9);
+    test.expect(10);
 
     var actual = read('tmp/jade.html');
     var expected = read('test/expected/jade.html');
@@ -46,6 +46,10 @@ exports.jade = {
     actual = read('tmp/jadeUsingmixin.html');
     expected = read('test/expected/jadeUsingmixin.html');
     test.equal(expected, actual, 'should compile jade with nested mixins');
+
+    actual = read('tmp/jadeCodeBlock.html');
+    expected = read('test/expected/jadeCodeBlock.html');
+    test.equal(expected, actual, 'should compile jade with codeblock');
 
     test.done();
   }


### PR DESCRIPTION
I updated to the latest jade and added a test for the new code blocks.
There are some other improvements as you can see in [Jade's History.md](https://github.com/jadejs/jade/blob/master/History.md)

Tests ran successfully.
Let me know, if I can improve something. :)